### PR TITLE
Implement missing events detection

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,8 +52,9 @@ I would pick that folder, not the `..\Desktop\ShadowExtracted\sys` folder, unlik
 ----
 #### This feature requires setting Dolphin MEM1 to 64MB mode! Be aware of this if you choose to use Layout Randomization, otherwise your game will crash on level load.
 
-#### A Warning about Reloaded <= 1.1 & 2P-Reloaded <= 1.0b
+#### A Warning about Reloaded <= 1.1
 If you use the "Random Partners" option, you may be unable to complete certain missions. To fix this issue, download the '[missing_events_reloaded_based_roms](https://github.com/ShadowTheHedgehogHacking/ShadowRando/releases/download/0.4.0/missing_events_reloaded_based_roms.7z)' and merge these into your extracted game's `events` folder. It can be done before or after your randomization.
+If your extracted game has this issue detected, a warning will display.
 
 ----
 

--- a/ShadowRando/Views/FirstScreen.axaml
+++ b/ShadowRando/Views/FirstScreen.axaml
@@ -14,7 +14,7 @@
 Using GCR and other game extraction methods are NOT supported, please follow the steps below instead (Dolphin extracted format method).
 
 ---Extraction of Game and Launching---
-1. Get the latest release or dev Dolphin
+1. Get the latest release of Dolphin, such as "Dolphin 2409" or newer
 2. (Optional: only do this step if you want to keep config separate) Before launching dolphin, create an empty file `portable.txt` in the same folder as Dolphin
 3. Open Dolphin
 4. Set game path to your Shadow the Hedgehog NTSC-U ISO
@@ -33,9 +33,6 @@ Using GCR and other game extraction methods are NOT supported, please follow the
 2. Select Advanced Tab
 3. In Memory Override section, check Enable Emulated Memory Size Override
 4. Slide MEM1 to 64 MB (maximum)
-
----Reloaded 1.1 and earlier based ROMs---
-If you use the "Random Partners" option, you may be unable to complete certain missions. To fix this issue, download the 'missing_events_reloaded_based_roms' and merge these into your extracted game's events folder. It can be done before or after your randomization. See the README on the Project Page for details. 
         </TextBlock>
 		<StackPanel Orientation="Horizontal" Margin="0,10,0,0">
 			<Button HorizontalAlignment="Center" VerticalContentAlignment="Center" HorizontalContentAlignment="Center" Height="40" Margin="15,0,10,0" Click="LoadNewGameFolder_OnClick">Pick Extracted Shadow the Hedgehog Game</Button>

--- a/ShadowRando/Views/FirstScreen.axaml.cs
+++ b/ShadowRando/Views/FirstScreen.axaml.cs
@@ -5,7 +5,7 @@ using Avalonia.Platform.Storage;
 using MsBox.Avalonia.Enums;
 using ShadowRando.Core;
 using System.IO;
-using System.Runtime.ExceptionServices;
+using System.Linq;
 
 namespace ShadowRando.Views;
 
@@ -15,6 +15,23 @@ public partial class FirstScreen : UserControl
 	private readonly MainWindow _mainWindow;
 	private bool buttonProcessing = false;
 	private Settings _settings;
+
+	private static readonly string[] reloaded_missing_event_names =
+	[
+		"event0811_sceneA.one",
+		"event0903_sceneA.one",
+		"event0906_sceneA.one",
+		"event0913_sceneA.one",
+		"event0915_sceneA.one",
+		"event0917_sceneA.one",
+		"event0919_sceneA.one",
+		"event0921_sceneA.one",
+		"event0922_sceneA.one",
+		"event0924_sceneA.one",
+		"event0925_sceneA.one",
+		"event0960_sceneA.one",
+		"event0961_sceneA.one"
+	];
 
 	public FirstScreen()
 	{
@@ -64,7 +81,7 @@ public partial class FirstScreen : UserControl
 	{
 		if (!Directory.Exists(gamePath))
 		{
-			Utils.ShowSimpleMessage("Error", "Folder not found.", ButtonEnum.Ok, Icon.Error);
+			_ = Utils.ShowSimpleMessage("Error", "Folder not found.", ButtonEnum.Ok, Icon.Error);
 			buttonProcessing = false;
 			return;
 		}
@@ -77,14 +94,20 @@ public partial class FirstScreen : UserControl
 
 		if (!File.Exists(Path.Combine(gamePath, "sys", "main.dol")) || !File.Exists(Path.Combine(gamePath, "sys", "bi2.bin")))
 		{
-			Utils.ShowSimpleMessage("Error", "Not a valid Shadow the Hedgehog Extracted game.", ButtonEnum.Ok, Icon.Error);
+			_ = Utils.ShowSimpleMessage("Error", "Not a valid Shadow the Hedgehog Extracted game.", ButtonEnum.Ok, Icon.Error);
 			buttonProcessing = false;
 			return;
 		}
 
+		bool missingEventsDetected = reloaded_missing_event_names.Any(eventName => !File.Exists(Path.Combine(gamePath, "files", "event", eventName)));
+		if (missingEventsDetected)
+		{
+			await Utils.ShowSimpleMessage("Missing Events Detected", $"We have detected missing event files in your game.\n\nIf you use the \"Random Partners\" option, you may be unable to complete certain missions.{Environment.NewLine}{Environment.NewLine}To fix this issue, download the 'missing_events_reloaded_based_roms'{Environment.NewLine}and merge these into your extracted game's events folder.{Environment.NewLine}It can be done before or after your randomization.{Environment.NewLine}{Environment.NewLine}See the README on the Project Page for details.", ButtonEnum.Ok, Icon.Warning);
+		}
+
 		if (_settings.GamePath != gamePath && Directory.Exists("backup"))
 		{
-			var msgbox = await Utils.ShowSimpleMessage("Shadow Randomizer", "New game directory selected!\n\nDo you wish to erase the previous backup data and use the new data as a base?", ButtonEnum.YesNoCancel, Icon.Question);
+			var msgbox = await Utils.ShowSimpleMessage("Shadow Randomizer", $"New game directory selected!{Environment.NewLine}{Environment.NewLine}Do you wish to erase the previous backup data and use the new data as a base?", ButtonEnum.YesNoCancel, Icon.Question);
 			switch (msgbox)
 			{
 				case ButtonResult.Yes:


### PR DESCRIPTION
* Removed the inaccurate info about 2P-Reloaded (unaffected)
* Removed the onboarding warning about this, and instead pop it up if detected in game folder (including on re-use last folder)
* Update onboarding message recommended Dolphin blurb
* This message does not prevent the user from continuing, incase they are not planning to use Partner Randomization
![image](https://github.com/user-attachments/assets/d77d01a6-b205-4c06-9e29-0b9f9d067eee)


Resolves #11 